### PR TITLE
Respecting manually specified foreign key for belongs-to and has-one...

### DIFF
--- a/src/korma/incubator/core.clj
+++ b/src/korma/incubator/core.clj
@@ -453,9 +453,9 @@
 
 (defn get-belongs-to-keys
   "Determines and returns the keys needed for belongs-to relationshiops."
-  [parent child]
+  [parent child opts]
   (let [pkk (:pk parent)
-        fkk (keyword (str (:table parent) "_id"))]
+        fkk (or (:fk opts) (keyword (str (:table parent) "_id")))]
     {:pk  (raw (eng/prefix parent pkk))
      :fk  (raw (eng/prefix child fkk))
      :fkk fkk}))
@@ -463,9 +463,9 @@
 (defn get-db-keys
   "Determines and returns the keys needed for has-one and has-many
    relationshiops."
-  [parent child]
+  [parent child opts]
   (let [pkk (:pk parent)
-        fkk (keyword (str (:table parent) "_id"))]
+        fkk (or (:fk opts) (keyword (str (:table parent) "_id")))]
     {:pk  (raw (eng/prefix parent pkk))
      :fk  (raw (eng/prefix child fkk))}))
 
@@ -475,8 +475,8 @@
   [type ent sub-ent opts]
   (condp = type
     :many-to-many [(many-to-many-keys ent sub-ent opts) sub-ent]
-    :has-one      [(get-db-keys ent sub-ent) sub-ent]
-    :belongs-to   [(get-belongs-to-keys sub-ent ent) ent]
+    :has-one      [(get-db-keys ent sub-ent opts) sub-ent]
+    :belongs-to   [(get-belongs-to-keys sub-ent ent opts) ent]
     :has-many     [(get-db-keys ent sub-ent) sub-ent]))
 
 (defn create-rel

--- a/src/korma/incubator/core.clj
+++ b/src/korma/incubator/core.clj
@@ -477,7 +477,7 @@
     :many-to-many [(many-to-many-keys ent sub-ent opts) sub-ent]
     :has-one      [(get-db-keys ent sub-ent opts) sub-ent]
     :belongs-to   [(get-belongs-to-keys sub-ent ent opts) ent]
-    :has-many     [(get-db-keys ent sub-ent) sub-ent]))
+    :has-many     [(get-db-keys ent sub-ent opts) sub-ent]))
 
 (defn create-rel
   [ent sub-ent type opts]

--- a/test/korma/incubator/test/core.clj
+++ b/test/korma/incubator/test/core.clj
@@ -477,7 +477,7 @@
     (is (= actual expected))))
 
 ;; Retrieving entities with has-one and belongs-to relationships separately.
-(declare hobt1 hobt2 hobt3 hobt4)
+(declare hobt1 hobt2 hobt3 hobt4 hobt5 hobt6)
 
 (defentity hobt1
   (entity-fields :field1)
@@ -494,6 +494,14 @@
 (defentity hobt4
   (entity-fields :field2)
   (has-one hobt3))
+
+(defentity hobt5
+  (entity-fields :field5)
+  (has-one hobt6 {:fk :exotic_id}))
+
+(defentity hobt6
+  (entity-fields :field6)
+  (belongs-to hobt5 {:fk :exotic_id}))
 
 (deftest with-object-has-one-before
   (let [actual   (with-out-str (dry-run (select hobt1 (with-object hobt2))))
@@ -521,4 +529,11 @@
         expected (str "dry run :: SELECT \"hobt4\".* FROM \"hobt4\" :: []\n"
                       "dry run :: SELECT \"hobt3\".* FROM \"hobt3\" "
                       "WHERE (\"hobt3\".\"hobt4_id\" = ?) :: [1]\n")]
+    (is (= actual expected))))
+
+(deftest with-object-has-one-exotic-foreign-key
+  (let [actual   (with-out-str (dry-run (select hobt5 (with-object hobt6))))
+        expected (str "dry run :: SELECT \"hobt5\".* FROM \"hobt5\" :: []\n"
+                      "dry run :: SELECT \"hobt6\".* FROM \"hobt6\" "
+                      "WHERE (\"hobt6\".\"exotic_id\" = ?) :: [1]\n")]
     (is (= actual expected))))


### PR DESCRIPTION
...relationships accessed by with-object.

The with-object implementation for has-one and belongs-to relationships currently does not respect manually specified foreign keys; instead it always sets its `fkk` foreign key keyword to `(keyword (str (:table parent) "_id"))`.

This commit fixes brings this functionality in line with the rest of korma, using the :fk option if available.

Could you merge in this pull request, and ideally push the updated jar to clojars? (there currently is no official 0.1.1 on clojars). Let me know if you have any thoughts/questions!
