### PR TITLE
Removed unused reference in core.clj

### DIFF
--- a/src/korma/incubator/core.clj
+++ b/src/korma/incubator/core.clj
@@ -7,7 +7,7 @@
             [clojure.string :as string]
             [korma.db :as db]
             [korma.config :as conf])
-  (:use [korma.sql.engine :only [bind-query bind-params]]))
+  (:use [korma.sql.engine :only [bind-query]]))
 
 (def ^{:dynamic true} *exec-mode* false)
 (declare get-rel)


### PR DESCRIPTION
bind-params is no longer public in korma.sql.engine. Since bind-params isn't used in core, it seems safe to remove.
